### PR TITLE
Implementation of a mock persistent container

### DIFF
--- a/UpcomingMovies/Scenes/Movies/MovieList/MovieListViewController.swift
+++ b/UpcomingMovies/Scenes/Movies/MovieList/MovieListViewController.swift
@@ -12,7 +12,7 @@ class MovieListViewController: UIViewController, Retryable, SegueHandler, Loader
     
     @IBOutlet weak var tableView: UITableView!
     
-    var viewModel: MovieListViewModel = MovieListViewModel()
+    var viewModel: MovieListViewModel!
     
     private var dataSource: SimpleTableViewDataSource<MovieCellViewModel>!
     private var prefetchDataSource: TableViewDataSourcePrefetching!

--- a/UpcomingMovies/Scenes/Movies/MovieList/MovieListViewModel.swift
+++ b/UpcomingMovies/Scenes/Movies/MovieList/MovieListViewModel.swift
@@ -27,8 +27,7 @@ final class MovieListViewModel: MoviesViewModel {
     
     // MARK: - Initializers
     
-    init(filter: MovieListFilter = .upcoming,
-         managedObjectContext: NSManagedObjectContext = PersistenceManager.shared.mainContext) {
+    init(filter: MovieListFilter = .upcoming, managedObjectContext: NSManagedObjectContext) {
         self.filter = filter
         self.managedObjectContext = managedObjectContext
     }

--- a/UpcomingMovies/Scenes/Movies/UpcomingMovies/UpcomingMoviesViewModel.swift
+++ b/UpcomingMovies/Scenes/Movies/UpcomingMovies/UpcomingMoviesViewModel.swift
@@ -29,7 +29,7 @@ final class UpcomingMoviesViewModel: MoviesViewModel {
         return movies.compactMap { UpcomingMovieCellViewModel($0) }
     }
     
-    init(managedObjectContext: NSManagedObjectContext = PersistenceManager.shared.persistentContainer.viewContext) {
+    init(managedObjectContext: NSManagedObjectContext = PersistenceManager.shared.mainContext) {
         self.managedObjectContext = managedObjectContext
     }
     

--- a/UpcomingMovies/ViewComponents/Xibs/FavoriteMovieCollectionViewCell.xib
+++ b/UpcomingMovies/ViewComponents/Xibs/FavoriteMovieCollectionViewCell.xib
@@ -23,7 +23,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="241" height="93"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </imageView>
-                    <view alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4HS-u4-vHQ" userLabel="Overlay View">
+                    <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4HS-u4-vHQ" userLabel="Overlay View">
                         <rect key="frame" x="0.0" y="0.0" width="241" height="93"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>

--- a/UpcomingMovies/ViewComponents/Xibs/UpcomingMovieDetailCollectionViewCell.xib
+++ b/UpcomingMovies/ViewComponents/Xibs/UpcomingMovieDetailCollectionViewCell.xib
@@ -25,7 +25,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bqj-81-ruL">
                                 <rect key="frame" x="0.0" y="0.0" width="333" height="106"/>
                             </imageView>
-                            <view alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xfj-OO-THV" userLabel="Overlay View">
+                            <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xfj-OO-THV" userLabel="Overlay View">
                                 <rect key="frame" x="0.0" y="0.0" width="333" height="106"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>

--- a/UpcomingMoviesTests/MovieDetailTests.swift
+++ b/UpcomingMoviesTests/MovieDetailTests.swift
@@ -13,9 +13,11 @@ import CoreData
 class MovieDetailTests: XCTestCase {
     
     private var viewModelToTest: MovieDetailViewModel!
+    private var context: NSManagedObjectContext!
 
     override func setUp() {
         super.setUp()
+        context = PersistenceManager.shared.mainContext
         setupMovieGenres()
         let movieToTest = Movie(id: 1,
                             title: "Test 1",
@@ -26,16 +28,16 @@ class MovieDetailTests: XCTestCase {
                             backdropPath: "/2Ah63TIvVmZM3hzUwR5hXFg2LEk.jpg",
                             releaseDate: "2019-02-01", voteAverage: 4.5)
         viewModelToTest = MovieDetailViewModel(movieToTest,
-                                               managedObjectContext: PersistenceManager.shared.mainContext)
+                                               managedObjectContext: context)
     }
 
     override func tearDown() {
         viewModelToTest = nil
+        context = nil
         super.tearDown()
     }
     
     private func setupMovieGenres() {
-        let context = PersistenceManager.shared.mainContext
         _ = Genre.with(id: 1, name: "Genre 1", context: context)
         _ = Genre.with(id: 2, name: "Genre 2", context: context)
     }


### PR DESCRIPTION
Resolves #62 

A mock persistent container with an InMemoryStore type was created so we can test our core data methods without altering the main persistent container.

On the PersistenceManager singleton, we check if the app is running in test mode or not to decide which persistent container we should use.